### PR TITLE
Removed compilation warnings.

### DIFF
--- a/red-engine.c
+++ b/red-engine.c
@@ -209,7 +209,7 @@ init_db (const struct red_conf conf)
 {
   /* Verify DB path.  */
   if ( (! conf.home_dir)
-       || (conf.home_dir == '\0'))
+       || (conf.home_dir[0] == '\0'))
     LOG_AND_RET ("Invalid home directory.", -1);
 
   /* Set up a concurrent Berkeley DB environment.  */

--- a/red-engine.h
+++ b/red-engine.h
@@ -1,7 +1,7 @@
 #ifndef RED_ENGINE_H
 #define RED_ENGINE_H
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <unistd.h>
 #include <stdarg.h>


### PR DESCRIPTION
I tried compiling red-engine with gcc 9.1.1 and ran into a couple of compilation warnings.
This commit fixes them.